### PR TITLE
Avoid summing up the first value twice

### DIFF
--- a/src/keewee.py
+++ b/src/keewee.py
@@ -79,7 +79,8 @@ def rec_mode_sum(kw_store: dict[str, int | float], key: str, value: int | float)
     """
     if kw_store.get(key) is None:
         kw_store[key] = value
-    kw_store[key] += value
+    else:
+        kw_store[key] += value
 
 
 def rec_mode_max(kw_store: dict[str, int | float], key: str, value: int | float) -> None:

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -25,9 +25,9 @@ class PokemonTrainerMin:
 class TestModes(unittest.TestCase):
 
     def test_mode_sum(self):
-        pokemon_trainer = PokemonTrainerSum(name='Ash Ketchum', skill_level=0)
-        pokemon_trainer.skill_level = 1
-        self.assertEqual(KeeWee.dumpd().get("PokemonTrainerSum").get("skill_level").get("PokemonTrainerSum(name='Ash Ketchum')"), 1)
+        pokemon_trainer = PokemonTrainerSum(name='Ash Ketchum', skill_level=1)
+        pokemon_trainer.skill_level = 2
+        self.assertEqual(KeeWee.dumpd().get("PokemonTrainerSum").get("skill_level").get("PokemonTrainerSum(name='Ash Ketchum')"), 3)
 
     def test_mode_max(self):
         pokemon_trainer = PokemonTrainerMax(name='Ash Ketchum', skill_level=0)


### PR DESCRIPTION
The "sum" mode sums up the first value twice.

The unit test with initial value 0 and added value 1 did not catch that, as `0 + 0 + 1 = 1` as expected. A different test, with initial value 1 and added value 2 can catch that, as `1 + 1 + 2 = 4` instead of the expected `1 + 2 = 3`.